### PR TITLE
fix: enforce dotfiles folder contracts

### DIFF
--- a/.github/workflows/reliability-gates.yml
+++ b/.github/workflows/reliability-gates.yml
@@ -132,3 +132,8 @@ jobs:
           set -euo pipefail
           ./install_packages.sh --check combined
           echo "Software manifests are valid"
+
+      - name: Verify folder contracts
+        run: |
+          set -euo pipefail
+          ./scripts/verify_folder_contracts.sh

--- a/.github/workflows/syntax-gate.yml
+++ b/.github/workflows/syntax-gate.yml
@@ -77,3 +77,8 @@ jobs:
             ./install_packages.sh --check combined
           fi
           echo "Software manifests validated"
+
+      - name: Folder contract validation
+        run: |
+          set -euo pipefail
+          ./scripts/verify_folder_contracts.sh

--- a/README.md
+++ b/README.md
@@ -337,6 +337,16 @@ The following will only happen if you agree on the prompt
 Run `./install_packages.sh` directly if you want to install just the package manifests without the rest of the system configuration.
 You can also run `./install.sh ./software` to point the full installer at a different software manifest directory.
 
+## Repository Folder Contracts
+
+The installer keeps user-facing files separated by their target location:
+
+- `homedir/` is symlinked into `$HOME` through GNU Stow.
+- `config/` is symlinked under `~/.config` through GNU Stow.
+- `scripts/` contains executable utilities stowed into `$HOME/.local/bin` as global commands.
+
+Run `./scripts/verify_folder_contracts.sh` after changing `install.sh`, `homedir/.shellpaths`, or `scripts/` to verify these contracts without running the full installer.
+
 The following is the default common software set:
 
 ## Utilities

--- a/homedir/.shellpaths
+++ b/homedir/.shellpaths
@@ -1,6 +1,6 @@
 #My Scripts
 export PATH=$PATH:.
-#export PATH=$PATH:~/.dotfiles/scripts
+export PATH="$HOME/.local/bin:$PATH"
 
 #Brew
 export PATH=/opt/homebrew/sbin:$PATH

--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,13 @@ stow -v -d "$DOTFILES_DIR" -t "$HOME" homedir || exit 1
 bot "symlinking .config dotfiles with GNU stow"
 stow -v -d "$DOTFILES_DIR" -t "$HOME/.config" config || exit 1
 
+bot "symlinking user scripts with GNU stow"
+mkdir -p "$HOME/.local/bin"
+stow -v -d "$DOTFILES_DIR" -t "$HOME/.local/bin" \
+  --ignore='README.md' \
+  --ignore='miyooogameslist.py' \
+  scripts || exit 1
+
 bot "VIM Setup"
 if [[ -z ${CI:-} ]]; then
   read -r -p "Do you want to install vim plugins now? [y|N] " response

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,10 +1,23 @@
 # Collected shell helper scripts
 
+Files in this directory that are executable are intended to be available as
+global shell commands through the dotfiles setup. The installer stows command
+scripts into `$HOME/.local/bin`.
+
+## convert-android-keystore.sh
+
+Converts an Android keystore through a PKCS#12 intermediate into a new JKS
+keystore.
+
 ## delete_files.sh
 
 **alias:** delete-files
 
 Deletes all files that meet a certain structure
+
+## ide
+
+Creates the tmux pane layout used for an IDE-style terminal workspace.
 
 ## line_extract.sh
 
@@ -13,3 +26,14 @@ Deletes all files that meet a certain structure
 Extracts all lines of a given file (for example logcat) based on regex criteria
 
 `line-extract PATTERN FILE`
+
+## miyooogameslist.py
+
+Not installed as a global command. This is a local helper script for generating
+a Miyoo game list from a fixed ROM directory.
+
+## verify_folder_contracts.sh
+
+Verifies that the repository folder contracts are intact: `homedir/` stows into
+`$HOME`, `config/` stows under `~/.config`, and executable files in `scripts/`
+are exposed as global commands.

--- a/scripts/verify_folder_contracts.sh
+++ b/scripts/verify_folder_contracts.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+
+errors=0
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  errors=$((errors + 1))
+}
+
+ok() {
+  printf 'OK: %s\n' "$1"
+}
+
+require_dir() {
+  local dir="$1"
+
+  if [[ -d "$ROOT_DIR/$dir" ]]; then
+    ok "$dir/ exists"
+  else
+    fail "$dir/ is missing"
+  fi
+}
+
+require_install_contract() {
+  local description="$1"
+  local pattern="$2"
+
+  if grep -Eq "$pattern" "$ROOT_DIR/install.sh"; then
+    ok "$description"
+  else
+    fail "$description"
+  fi
+}
+
+require_file_contains() {
+  local description="$1"
+  local file="$2"
+  local pattern="$3"
+
+  if grep -Eq "$pattern" "$ROOT_DIR/$file"; then
+    ok "$description"
+  else
+    fail "$description"
+  fi
+}
+
+validate_command_script() {
+  local script="$1"
+  local first_line
+
+  if [[ ! -x "$script" ]]; then
+    fail "${script#$ROOT_DIR/} is not executable"
+    return
+  fi
+
+  IFS= read -r first_line < "$script" || first_line=""
+  if [[ ! "$first_line" =~ ^#! ]]; then
+    fail "${script#$ROOT_DIR/} is missing a shebang"
+  else
+    ok "${script#$ROOT_DIR/} has executable metadata"
+  fi
+}
+
+require_dir "homedir"
+require_dir "config"
+require_dir "scripts"
+
+require_install_contract "install.sh stows homedir/ into HOME" \
+  'stow[[:space:]].*-d[[:space:]]+"\$DOTFILES_DIR"[[:space:]].*-t[[:space:]]+"\$HOME"[[:space:]]+homedir'
+require_install_contract "install.sh creates HOME/.config before config stow" \
+  'mkdir[[:space:]]+-p[[:space:]]+"\$HOME/\.config"'
+require_install_contract "install.sh stows config/ into HOME/.config" \
+  'stow[[:space:]].*-d[[:space:]]+"\$DOTFILES_DIR"[[:space:]].*-t[[:space:]]+"\$HOME/\.config"[[:space:]]+config'
+
+require_install_contract "install.sh creates HOME/.local/bin before scripts stow" \
+  'mkdir[[:space:]]+-p[[:space:]]+"\$HOME/\.local/bin"'
+require_install_contract "install.sh targets HOME/.local/bin for scripts stow" \
+  'stow[[:space:]].*-d[[:space:]]+"\$DOTFILES_DIR"[[:space:]].*-t[[:space:]]+"\$HOME/\.local/bin"'
+require_install_contract "install.sh stows scripts/ package" \
+  'scripts[[:space:]]*\|\|[[:space:]]*exit[[:space:]]+1'
+require_file_contains "homedir/.shellpaths exposes HOME/.local/bin on PATH" \
+  "homedir/.shellpaths" '\$HOME/\.local/bin'
+
+while IFS= read -r script; do
+  validate_command_script "$script"
+done < <(find "$ROOT_DIR/scripts" -maxdepth 1 -type f -perm -111 | sort)
+
+if [[ $errors -gt 0 ]]; then
+  printf '\n%d folder contract check(s) failed.\n' "$errors" >&2
+  exit 1
+fi
+
+printf '\nFolder contracts verified.\n'


### PR DESCRIPTION
## Summary

The folder contracts now match the installer behavior. `homedir/` and `config/` remain GNU Stow-managed in their existing targets, and executable scripts are now stowed into the standard user command directory at `$HOME/.local/bin` instead of relying on a clone-path-specific PATH entry.

A focused verifier now checks the folder mapping, installer stow targets, PATH exposure, and executable script metadata. The same verifier runs in the existing syntax and reliability gates so future drift is caught without running a full bootstrap.

## Validation

- `./scripts/verify_folder_contracts.sh`
- `bash -n install.sh scripts/verify_folder_contracts.sh scripts/delete_files.sh scripts/line_extract.sh scripts/convert-android-keystore.sh`
- `zsh -n homedir/.shellpaths`
- `shellcheck --severity=error --shell=bash --exclude=SC1090,SC1091,SC1087 install.sh scripts/verify_folder_contracts.sh scripts/delete_files.sh scripts/line_extract.sh scripts/convert-android-keystore.sh`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "OK: #{f}" }' .github/workflows/reliability-gates.yml .github/workflows/syntax-gate.yml`
- `./install_packages.sh --check combined`
- `git diff --cached --check`

## Post-Deploy Monitoring & Validation

No additional production monitoring required. This is a dotfiles installer and CI validation change; healthy signals are the PR checks passing and a local `./scripts/verify_folder_contracts.sh` run reporting `Folder contracts verified.`

Failure signals are stow conflicts in `$HOME/.local/bin`, missing executable metadata for command scripts, or CI failures in the folder contract validation step. Mitigation is to fix the conflicting script inventory or stow target before rerunning bootstrap.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
