### PR TITLE
fix: bootstrap ide tmux session

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -17,7 +17,8 @@ Deletes all files that meet a certain structure
 
 ## ide
 
-Creates the tmux pane layout used for an IDE-style terminal workspace.
+Starts tmux when needed and creates the pane layout used for an IDE-style
+terminal workspace. Prints a clear error when tmux is not installed.
 
 ## line_extract.sh
 

--- a/scripts/ide
+++ b/scripts/ide
@@ -1,4 +1,32 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if ! command -v tmux >/dev/null 2>&1; then
+  printf 'tmux is required to start the IDE layout, but it is not installed or not on PATH.\n' >&2
+  printf 'Install tmux first, then run this command again.\n' >&2
+  exit 1
+fi
+
+if [[ -z "${TMUX:-}" ]]; then
+  session_name="ide-${USER:-user}-$$"
+  script_path="$0"
+
+  if [[ "$script_path" != */* ]]; then
+    script_path="$(command -v "$script_path")"
+  fi
+
+  printf -v command_line '%q' "$script_path"
+  for arg in "$@"; do
+    printf -v quoted_arg '%q' "$arg"
+    command_line+=" $quoted_arg"
+  done
+
+  tmux new-session -d -s "$session_name" -c "$PWD"
+  tmux send-keys -t "$session_name" "$command_line" C-m
+  exec tmux attach-session -t "$session_name"
+fi
+
 tmux split-window -h -l 20%
 tmux select-pane -L
 tmux split-window -v -l 30%


### PR DESCRIPTION
## Summary

`ide` now behaves like a command users can run from any shell state. It reports a clear install-time prerequisite when `tmux` is unavailable, starts a tmux session when invoked from a regular shell, and keeps the existing pane layout behavior when already inside tmux.

The scripts documentation now reflects that bootstrap behavior so the command surface is easier to understand after the folder-contract changes.

## Validation

- `bash -n scripts/ide`
- `shellcheck --severity=error --shell=bash --exclude=SC1090,SC1091,SC1087 scripts/ide`
- `./scripts/verify_folder_contracts.sh`
- `env PATH=/usr/bin:/bin scripts/ide`
- `git diff --check`

## Post-Deploy Monitoring & Validation

No additional production monitoring required. This is a local dotfiles utility change; healthy signals are the PR checks passing and `ide` either opening the tmux layout or printing the missing-tmux message when `tmux` is unavailable.

Failure signals are `ide` failing to attach a tmux session outside tmux, shell syntax failures, or folder-contract validation failures. Mitigation is to revert this script change or run `ide` manually after installing tmux to inspect the session bootstrap path.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
