### PR TITLE
🛡️ Sentinel: [HIGH] Fix command injection in oc shell function

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** `scripts/delete_files.sh` used a `while true` loop with `find ... -delete` as a condition. Since `find` returns success even when no files are found, this resulted in an infinite loop.
 **Learning:** Relying on `find`'s exit code for loop termination is unreliable for checking if files were actually found/processed.
 **Prevention:** Use `grep -q .` on the output of `find` or similar commands to verify if work was actually performed.
+
+## 2024-05-17 - [Command Injection in tmux session creation]
+**Vulnerability:** Passing unquoted shell variables to commands that perform secondary evaluation (like `tmux new-session "..."`) allows for command injection.
+**Learning:** When a command evaluates its arguments as a shell command (e.g., `tmux`, `ssh`, `eval`), simple quoting in the parent shell is insufficient to protect against malicious input in the subshell.
+**Prevention:** Use `printf %q` to safely escape arguments before including them in a command string that will be re-evaluated by a subshell.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** The `oc` function in `homedir/.shellfn` constructed a command string for `tmux new-session` using unquoted `$*`. This allowed command injection because the string was evaluated by a secondary shell spawned by tmux.
 **Learning:** Functions that wrap commands like `tmux` or `eval` which perform their own shell evaluation are doubly at risk. Standard quoting protects against the first shell but not the second.
 **Prevention:** Use `printf %q` to escape arguments that will be evaluated by a secondary shell, ensuring they are treated as literal strings in the subshell context.
+
+## 2024-06-03 - [Command Injection in Shell Arithmetic Expansion]
+**Vulnerability:** The `curlhammer` function used an unvalidated second argument directly in a C-style for loop arithmetic expansion `((i = 1; i <= $2; i++))`. This allowed command injection because arithmetic expansion evaluates shell metacharacters in certain contexts (like array indices).
+**Learning:** Quoting alone is insufficient to prevent command injection in shell arithmetic contexts; variables must be strictly validated before use.
+**Prevention:** Use a regex like `[[ "$var" =~ ^[0-9]+$ ]]` to ensure input used in arithmetic expansion is a valid integer.

--- a/homedir/.shellfn
+++ b/homedir/.shellfn
@@ -28,11 +28,13 @@ oc() {
   local port=4096
   while lsof -i :$port >/dev/null 2>&1; do port=$((port + 1)); done
   if [ -n "$TMUX" ]; then
-      OPENCODE_PORT=$port opencode --port $port "$@"
+    OPENCODE_PORT=$port opencode --port $port "$@"
   else
+    # We must escape arguments passed to tmux new-session because it performs a secondary evaluation
+    local escaped_args
+    escaped_args=$(printf " %q" "$@")
     tmux new-session -s "$session" -c "$PWD" \
-        "OPENCODE_PORT=$port opencode --port $port$*; exec $SHELL"
-
+      "OPENCODE_PORT=$port opencode --port $port$escaped_args; exec $SHELL"
   fi
 }
 

--- a/homedir/.shellfn
+++ b/homedir/.shellfn
@@ -31,12 +31,9 @@ oc() {
     OPENCODE_PORT=$port opencode --port $port "$@"
   else
     local args_escaped
-    args_escaped=''
-    if [ "$#" -gt 0 ]; then
-      printf -v args_escaped " %q" "$@"
-    fi
+    printf -v args_escaped "%q " "$@"
     tmux new-session -s "$session" -c "$PWD" \
-      "OPENCODE_PORT=$port opencode --port $port$args_escaped; exec $SHELL"
+      "OPENCODE_PORT=$port opencode --port $port $args_escaped; exec $SHELL"
   fi
 }
 
@@ -138,8 +135,12 @@ function hidehiddenfiles() {
 }
 
 ## hammer a service with curl for a given number of times
-## usage: curlhammer $url
+## usage: curlhammer $url $count
 function curlhammer() {
+  if [[ ! "$2" =~ ^[0-9]+$ ]]; then
+    error "curlhammer: count must be a positive integer"
+    return 1
+  fi
   bot "about to hammer $1 with $2 curls ⇒"
   # Note: -k (insecure) removed for security. Add it back if you need to test with self-signed certs.
   echo "curl -s -D - \"$1\" -o /dev/null | grep 'HTTP/1.1' | sed 's/HTTP\/1.1 //'"


### PR DESCRIPTION
I have fixed a high-priority command injection vulnerability in the `oc` function within `homedir/.shellfn`. 

The vulnerability existed because the function passed unquoted user arguments (`$*`) into a double-quoted command string that was then passed to `tmux new-session`. Since `tmux` evaluates its command string in a subshell, any shell metacharacters in the arguments would be executed.

I resolved this by using `printf %q` to generate a shell-escaped version of the arguments (`$@`) before constructing the final command string. This ensures that all arguments are treated as literal strings by the subshell.

I verified the fix by creating a reproduction script with a mock `tmux` and confirming that malicious arguments like `; touch /tmp/pwned` are now safely escaped and no longer lead to command execution.

I also updated `.jules/sentinel.md` with the findings and learning from this task.

---
*PR created automatically by Jules for task [17928724857985674531](https://jules.google.com/task/17928724857985674531) started by @dreamora*