### PR TITLE
🛡️ Sentinel: Fix command injection in oc function

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** `scripts/delete_files.sh` used a `while true` loop with `find ... -delete` as a condition. Since `find` returns success even when no files are found, this resulted in an infinite loop.
 **Learning:** Relying on `find`'s exit code for loop termination is unreliable for checking if files were actually found/processed.
 **Prevention:** Use `grep -q .` on the output of `find` or similar commands to verify if work was actually performed.
+
+## 2024-06-03 - [Command Injection via Secondary Shell Evaluation in Tmux]
+**Vulnerability:** The `oc` function in `homedir/.shellfn` constructed a command string for `tmux new-session` using unquoted `$*`. This allowed command injection because the string was evaluated by a secondary shell spawned by tmux.
+**Learning:** Functions that wrap commands like `tmux` or `eval` which perform their own shell evaluation are doubly at risk. Standard quoting protects against the first shell but not the second.
+**Prevention:** Use `printf %q` to escape arguments that will be evaluated by a secondary shell, ensuring they are treated as literal strings in the subshell context.

--- a/homedir/.shellfn
+++ b/homedir/.shellfn
@@ -28,11 +28,12 @@ oc() {
   local port=4096
   while lsof -i :$port >/dev/null 2>&1; do port=$((port + 1)); done
   if [ -n "$TMUX" ]; then
-      OPENCODE_PORT=$port opencode --port $port "$@"
+    OPENCODE_PORT=$port opencode --port $port "$@"
   else
+    local args_escaped
+    printf -v args_escaped "%q " "$@"
     tmux new-session -s "$session" -c "$PWD" \
-        "OPENCODE_PORT=$port opencode --port $port$*; exec $SHELL"
-
+      "OPENCODE_PORT=$port opencode --port $port $args_escaped; exec $SHELL"
   fi
 }
 


### PR DESCRIPTION
I have identified and fixed a high-priority command injection vulnerability in the `oc` shell function located in `homedir/.shellfn`.

### 🚨 Severity: HIGH
### 💡 Vulnerability:
The `oc` function used `$*` inside a double-quoted string to construct a command for `tmux new-session`. This allowed any shell metacharacters in the arguments to be executed by the subshell spawned by tmux.

### 🎯 Impact:
An attacker (or even accidental usage with special characters in filenames) could execute arbitrary commands with the privileges of the user running the `oc` function. For example, `oc "; touch VULN"` would create a file named `VULN`.

### 🔧 Fix:
Modified the `oc` function to use `printf -v args_escaped "%q " "$@"` which safely escapes all positional arguments for reuse as shell input. This ensures that arguments are treated as literal strings in the secondary shell.

### ✅ Verification:
- Verified that malicious input like `; touch VULN` is now correctly escaped as `\;\ touch\ VULN` and does not execute.
- Confirmed that arguments with spaces and quotes are handled correctly.
- Performed a syntax check with `bash -n homedir/.shellfn`.
- Updated the security journal in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [1075549481272451036](https://jules.google.com/task/1075549481272451036) started by @dreamora*