### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in oc function

### DIFF
--- a/homedir/.shellfn
+++ b/homedir/.shellfn
@@ -38,7 +38,7 @@ oc() {
     local args_escaped
     printf -v args_escaped "%q " "$@"
     tmux new-session -s "$session" -c "$PWD" \
-        "OPENCODE_ENABLE_EXA=1 OPENCODE_PORT=$port opencode --port $port $*; exec $SHELL"
+        "OPENCODE_ENABLE_EXA=1 OPENCODE_PORT=$port opencode --port $port ${args_escaped}; exec $SHELL"
 
   fi
 }


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix command injection in oc function

🚨 Severity: CRITICAL
💡 Vulnerability: Command injection via secondary shell evaluation
🎯 Impact: An attacker could execute arbitrary commands if user-provided
   arguments to the 'oc' function contained shell metacharacters.
🔧 Fix: Replaced unquoted $* with ${args_escaped} (shell-escaped via
   printf %q) in the tmux new-session command string.
✅ Verification: Confirmed syntax with 'bash -n' and verified repository
   integrity with 'scripts/verify_folder_contracts.sh'.

---
*PR created automatically by Jules for task [5160920415992423702](https://jules.google.com/task/5160920415992423702) started by @dreamora*