### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in oc function

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** The `oc` function in `homedir/.shellfn` constructed a command string for `tmux new-session` using unquoted `$*`. This allowed command injection because the string was evaluated by a secondary shell spawned by tmux.
 **Learning:** Functions that wrap commands like `tmux` or `eval` which perform their own shell evaluation are doubly at risk. Standard quoting protects against the first shell but not the second.
 **Prevention:** Use `printf %q` to escape arguments that will be evaluated by a secondary shell, ensuring they are treated as literal strings in the subshell context.
+
+## 2026-06-12 - [Regression: Unused Escaped Variables in Tmux Command]
+**Vulnerability:** A previous fix for command injection in the `oc` function prepared an escaped variable (`args_escaped`) using `printf %q` but failed to use it in the final `tmux new-session` command, continuing to use the vulnerable `$*`.
+**Learning:** Security fixes involving variable preparation are only effective if the prepared variables are actually referenced in the execution sink. Regressions can occur if the "safe" variable is defined but the "unsafe" one is still used.
+**Prevention:** During code review and verification, specifically check that unsafe variables (like `$*` or `$@`) have been completely replaced by their sanitized or escaped counterparts in all command sinks.

--- a/homedir/.shellfn
+++ b/homedir/.shellfn
@@ -37,8 +37,9 @@ oc() {
   else
     local args_escaped
     printf -v args_escaped "%q " "$@"
+    # Use ${args_escaped} instead of $* to prevent command injection in secondary shell evaluation
     tmux new-session -s "$session" -c "$PWD" \
-        "OPENCODE_ENABLE_EXA=1 OPENCODE_PORT=$port opencode --port $port $*; exec $SHELL"
+        "OPENCODE_ENABLE_EXA=1 OPENCODE_PORT=$port opencode --port $port ${args_escaped}; exec $SHELL"
 
   fi
 }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `oc` function in `homedir/.shellfn` was vulnerable to command injection because it used unquoted `$*` when constructing a command string for `tmux new-session`. This allowed shell metacharacters in function arguments to be executed by the secondary shell spawned by tmux.
🎯 Impact: Arbitrary code execution.
🔧 Fix: Correctly utilized the `${args_escaped}` variable (populated via `printf %q`) in the `tmux` command string.
✅ Verification: Verified using a custom reproduction script that mocks tmux and confirms arguments are properly escaped. Syntax check and folder contract verification passed.

---
*PR created automatically by Jules for task [15809111355635052980](https://jules.google.com/task/15809111355635052980) started by @dreamora*