### PR TITLE
🛡️ Sentinel: Harden shell functions against command and option injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,13 @@
 **Vulnerability:** The `oc` function in `homedir/.shellfn` constructed a command string for `tmux new-session` using unquoted `$*`. This allowed command injection because the string was evaluated by a secondary shell spawned by tmux.
 **Learning:** Functions that wrap commands like `tmux` or `eval` which perform their own shell evaluation are doubly at risk. Standard quoting protects against the first shell but not the second.
 **Prevention:** Use `printf %q` to escape arguments that will be evaluated by a secondary shell, ensuring they are treated as literal strings in the subshell context.
+
+## 2024-06-14 - [Arithmetic Injection in Bash]
+**Vulnerability:** User-controlled variables used in Bash arithmetic expansions `(( ))` or `$(( ))` can lead to arbitrary command execution if they contain malicious array indices or other expressions.
+**Learning:** Quoting variables is insufficient for security in arithmetic contexts; strict regex-based integer validation (e.g., `[[ "$var" =~ ^[0-9]+$ ]]`) is required.
+**Prevention:** Always validate that variables used in arithmetic contexts are strictly integers.
+
+## 2024-06-14 - [Option Injection in CLI Tools]
+**Vulnerability:** Passing user-controlled input as arguments to CLI tools (like `curl` or `grep`) can allow an attacker to inject command-line options if the input starts with a dash.
+**Learning:** Even if arguments are quoted, they can still be interpreted as options by the target binary.
+**Prevention:** Use the `--` delimiter to signal the end of command options and treat all subsequent arguments as positional.

--- a/homedir/.shellfn
+++ b/homedir/.shellfn
@@ -33,12 +33,13 @@ oc() {
   local port=4096
   while lsof -i :$port >/dev/null 2>&1; do port=$((port + 1)); done
   if [ -n "$TMUX" ]; then
-      OPENCODE_ENABLE_EXA=1 OPENCODE_PORT=$port opencode --port $port "$@"
+      OPENCODE_ENABLE_EXA=1 OPENCODE_PORT=$port opencode --port "$port" "$@"
   else
     local args_escaped
+    # Escape arguments for secondary shell evaluation in tmux
     printf -v args_escaped "%q " "$@"
     tmux new-session -s "$session" -c "$PWD" \
-        "OPENCODE_ENABLE_EXA=1 OPENCODE_PORT=$port opencode --port $port $*; exec $SHELL"
+        "OPENCODE_ENABLE_EXA=1 OPENCODE_PORT=$port opencode --port $port ${args_escaped}; exec $SHELL"
 
   fi
 }
@@ -48,6 +49,11 @@ oc() {
 #########################################
 
 kill_on_port() {
+  # Strict integer validation to prevent command injection
+  if [[ ! "$1" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: Invalid port number." >&2
+    return 1
+  fi
   lsof -t -i :"$1" | xargs sudo kill -9
 }
 
@@ -114,13 +120,22 @@ function manp() {
 }
 
 ## hammer a service with curl for a given number of times
-## usage: curlhammer $url
+## usage: curlhammer $url $count
 function curlhammer() {
-  bot "about to hammer $1 with $2 curls ⇒"
+  # Strict integer validation for count to prevent arithmetic injection
+  if [[ ! "$2" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: Invalid count." >&2
+    return 1
+  fi
+  local url_escaped count_escaped
+  printf -v url_escaped "%q" "$1"
+  printf -v count_escaped "%q" "$2"
+  bot "about to hammer ${url_escaped} with ${count_escaped} curls ⇒"
+
   # Note: -k (insecure) removed for security. Add it back if you need to test with self-signed certs.
-  echo "curl -s -D - \"$1\" -o /dev/null | grep 'HTTP/1.1' | sed 's/HTTP\/1.1 //'"
+  echo "curl -s -D - -o /dev/null -- \"$1\" | grep 'HTTP/1.1' | sed 's/HTTP\/1.1 //'"
   for ((i = 1; i <= $2; i++)); do
-    curl -s -D - "$1" -o /dev/null | grep 'HTTP/1.1' | sed 's/HTTP\/1.1 //'
+    curl -s -D - -o /dev/null -- "$1" | grep 'HTTP/1.1' | sed 's/HTTP\/1.1 //'
   done
   bot "done"
 }
@@ -130,11 +145,16 @@ function curlhammer() {
 ## usage: curlheader $url
 function curlheader() {
   if [[ -z "$2" ]]; then
-    echo "curl -s -D - \"$1\" -o /dev/null"
-    curl -s -D - "$1" -o /dev/null
+    local url_escaped
+    printf -v url_escaped "%q" "$1"
+    echo "curl -s -D - -o /dev/null -- ${url_escaped}"
+    curl -s -D - -o /dev/null -- "$1"
   else
-    echo "curl -s -D - \"$2\" -o /dev/null | grep \"$1:\""
-    curl -s -D - "$2" -o /dev/null | grep "$1:"
+    local header_escaped url_escaped
+    printf -v header_escaped "%q" "$1"
+    printf -v url_escaped "%q" "$2"
+    echo "curl -s -D - -o /dev/null -- ${url_escaped} | grep \"${header_escaped}:\""
+    curl -s -D - -o /dev/null -- "$2" | grep "$1:"
   fi
 }
 
@@ -148,7 +168,7 @@ function curltime() {
      time_redirect:  %{time_redirect}\n\
 time_starttransfer:  %{time_starttransfer}\n\
 --------------------------\n\
-        time_total:  %{time_total}\n" -o /dev/null -s "$1"
+        time_total:  %{time_total}\n" -o /dev/null -s -- "$1"
 }
 
 function fixperms() {
@@ -184,8 +204,10 @@ function tre(){
 }
 
 function weather() {
-  curl wttr.in/$1
+  # Quoting and -- delimiter to prevent option injection
+  curl -- "wttr.in/${1}"
 }
 function ipinfo(){
-  curl ipinfo.io/$1
+  # Quoting and -- delimiter to prevent option injection
+  curl -- "ipinfo.io/${1}"
 }


### PR DESCRIPTION
Hardened several shell functions in `homedir/.shellfn` to protect against command injection, arithmetic injection, and option injection. Key improvements include strict integer validation, proper quoting, use of the `--` delimiter for CLI tools, and escaping arguments for secondary shell evaluation.

---
*PR created automatically by Jules for task [5176150743235017597](https://jules.google.com/task/5176150743235017597) started by @dreamora*