### PR TITLE
🛡️ Sentinel: Fix shell injection vulnerabilities in .shellfn

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,13 @@
 **Vulnerability:** The `oc` function in `homedir/.shellfn` constructed a command string for `tmux new-session` using unquoted `$*`. This allowed command injection because the string was evaluated by a secondary shell spawned by tmux.
 **Learning:** Functions that wrap commands like `tmux` or `eval` which perform their own shell evaluation are doubly at risk. Standard quoting protects against the first shell but not the second.
 **Prevention:** Use `printf %q` to escape arguments that will be evaluated by a secondary shell, ensuring they are treated as literal strings in the subshell context.
+
+## 2024-06-03 - [Arithmetic Injection in Shell Loops]
+**Vulnerability:** Shell arithmetic expansion `(( ))` and C-style for loops `for ((i=1; i<=$n; i++))` are vulnerable to injection if `$n` is user-controlled. An attacker can use array index evaluation (e.g., `a[$(cmd)0]`) to execute arbitrary commands.
+**Learning:** Quoting alone is insufficient to prevent injection in arithmetic contexts.
+**Prevention:** Strictly validate user-provided variables used in arithmetic expansion as integers using a regex like `[[ "$var" =~ ^[0-9]+$ ]]`.
+
+## 2024-06-03 - [Command Injection via Missing Delimiters and Quoting]
+**Vulnerability:** Multiple shell functions (`weather`, `ipinfo`, `curlheader`, `gitnr`) were vulnerable to command and option injection due to unquoted variables and missing `--` delimiters.
+**Learning:** User input passed to CLI tools like `curl`, `mkdir`, and `cd` can be interpreted as options or commands if not properly handled.
+**Prevention:** Always quote variables and use the `--` delimiter to signal the end of command options.

--- a/homedir/.shellfn
+++ b/homedir/.shellfn
@@ -37,8 +37,9 @@ oc() {
   else
     local args_escaped
     printf -v args_escaped "%q " "$@"
+    # Use prepared args_escaped to prevent command injection in secondary shell evaluation
     tmux new-session -s "$session" -c "$PWD" \
-        "OPENCODE_ENABLE_EXA=1 OPENCODE_PORT=$port opencode --port $port $*; exec $SHELL"
+        "OPENCODE_ENABLE_EXA=1 OPENCODE_PORT=$port opencode --port $port ${args_escaped}; exec $SHELL"
 
   fi
 }
@@ -48,7 +49,13 @@ oc() {
 #########################################
 
 kill_on_port() {
-  lsof -t -i :"$1" | xargs sudo kill -9
+  # Validate that the port is a number to prevent command injection
+  if [[ "$1" =~ ^[0-9]+$ ]]; then
+    lsof -t -i :"$1" | xargs sudo kill -9
+  else
+    echo "Error: Invalid port number" >&2
+    return 1
+  fi
 }
 
 #########################################
@@ -106,7 +113,10 @@ function cd() {
 #########################################
 
 # Create a new git repo with one README commit and CD into it
-function gitnr() { mkdir $1; cd $1; git init; touch "README.md"; git add "README.md"; git commit -m "Initial commit";}
+function gitnr() {
+  # Use -- to prevent directory names from being interpreted as options
+  mkdir -- "$1" && cd -- "$1" && git init && touch "README.md" && git add "README.md" && git commit -m "Initial commit";
+}
 
 # Use Mac OS Preview to open a man page in a more handsome format
 function manp() {
@@ -114,13 +124,18 @@ function manp() {
 }
 
 ## hammer a service with curl for a given number of times
-## usage: curlhammer $url
+## usage: curlhammer $url $count
 function curlhammer() {
+  # Validate that the count is an integer to prevent arithmetic injection
+  if [[ ! "$2" =~ ^[0-9]+$ ]]; then
+    echo "Error: Invalid count. Must be an integer." >&2
+    return 1
+  fi
   bot "about to hammer $1 with $2 curls ⇒"
   # Note: -k (insecure) removed for security. Add it back if you need to test with self-signed certs.
   echo "curl -s -D - \"$1\" -o /dev/null | grep 'HTTP/1.1' | sed 's/HTTP\/1.1 //'"
   for ((i = 1; i <= $2; i++)); do
-    curl -s -D - "$1" -o /dev/null | grep 'HTTP/1.1' | sed 's/HTTP\/1.1 //'
+    curl -s -D - -- "$1" -o /dev/null | grep 'HTTP/1.1' | sed 's/HTTP\/1.1 //'
   done
   bot "done"
 }
@@ -131,10 +146,10 @@ function curlhammer() {
 function curlheader() {
   if [[ -z "$2" ]]; then
     echo "curl -s -D - \"$1\" -o /dev/null"
-    curl -s -D - "$1" -o /dev/null
+    curl -s -D - -- "$1" -o /dev/null
   else
     echo "curl -s -D - \"$2\" -o /dev/null | grep \"$1:\""
-    curl -s -D - "$2" -o /dev/null | grep "$1:"
+    curl -s -D - -- "$2" -o /dev/null | grep -F -- "$1:"
   fi
 }
 
@@ -184,8 +199,8 @@ function tre(){
 }
 
 function weather() {
-  curl wttr.in/$1
+  curl -s -- "wttr.in/$1"
 }
 function ipinfo(){
-  curl ipinfo.io/$1
+  curl -s -- "ipinfo.io/$1"
 }


### PR DESCRIPTION
I have identified and fixed several critical and high-priority security vulnerabilities in the shell utility functions within `homedir/.shellfn`. 

Specifically:
- **Command Injection via Tmux**: The `oc` function was vulnerable to command injection because it passed unescaped arguments to `tmux new-session`, which performs its own shell evaluation. I've switched to using `printf %q` to safely escape these arguments.
- **Arithmetic Injection**: The `curlhammer` function was vulnerable to command execution via arithmetic expansion in a C-style for loop. I've added regex validation (`[[ "$var" =~ ^[0-9]+$ ]]`) to ensure the count is a safe integer.
- **Command/Option Injection**: Functions like `weather`, `ipinfo`, and `gitnr` were vulnerable because they didn't quote variables or use the `--` delimiter, allowing an attacker to inject flags or additional commands. I've added proper quoting and delimiters.
- **Input Validation**: `kill_on_port` now validates that the port is a numeric value before passing it to `lsof`.

I've also updated the Sentinel security journal in `.jules/sentinel.md` to document these findings for future reference.

All changes were verified using reproduction scripts (which have been cleaned up) and syntax validation (`bash -n`).

---
*PR created automatically by Jules for task [255664523186344729](https://jules.google.com/task/255664523186344729) started by @dreamora*