### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix command injection and credential exposure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** Shell arithmetic expansion `(( ))` or `$(( ))` can be exploited for command execution via array index evaluation (e.g., `a[$(id)0]`) if user-provided variables are not strictly validated as integers.
 **Learning:** Quoting does not protect against this; only strict regex-based integer validation (`[[ "$var" =~ ^[0-9]+$ ]]`) is effective.
 **Prevention:** Always validate user-provided variables used in arithmetic contexts as integers before use.
+
+## 2025-01-24 - [Regression: Unused Escaped Variables in Tmux Commands]
+**Vulnerability:** A previous fix for the `oc` function prepared an `args_escaped` variable using `printf %q` but failed to actually use it in the `tmux new-session` command, continuing to use the vulnerable `$*`.
+**Learning:** Security fixes must be verified not only for their presence but for their actual integration into the execution path. Unused security variables provide no protection.
+**Prevention:** Always verify that prepared security-hardened variables are correctly referenced in the final command construction.

--- a/homedir/.shellfn
+++ b/homedir/.shellfn
@@ -37,8 +37,9 @@ oc() {
   else
     local args_escaped
     printf -v args_escaped "%q " "$@"
+    # args_escaped contains the properly escaped arguments for the secondary shell
     tmux new-session -s "$session" -c "$PWD" \
-        "OPENCODE_ENABLE_EXA=1 OPENCODE_PORT=$port opencode --port $port $*; exec $SHELL"
+        "OPENCODE_ENABLE_EXA=1 OPENCODE_PORT=$port opencode --port $port ${args_escaped}; exec $SHELL"
 
   fi
 }
@@ -111,7 +112,10 @@ function cd() {
 #########################################
 
 # Create a new git repo with one README commit and CD into it
-function gitnr() { mkdir $1; cd $1; git init; touch "README.md"; git add "README.md"; git commit -m "Initial commit";}
+function gitnr() {
+  # Defensive coding: quote variables and use -- to prevent option injection
+  mkdir -- "$1" && cd -- "$1" && git init && touch "README.md" && git add "README.md" && git commit -m "Initial commit";
+}
 
 # Use Mac OS Preview to open a man page in a more handsome format
 function manp() {

--- a/scripts/convert-android-keystore.sh
+++ b/scripts/convert-android-keystore.sh
@@ -5,11 +5,15 @@ KEYSTORE_PASS=$2
 KEYSTORE_IN=$3
 KEYSTORE_OUT=$4
 
+# Security Standard: Passwords should be passed via environment variables
+# to prevent them from appearing in the process list.
+export KS_PASS="$KEYSTORE_PASS"
+
 # Export certificate
 keytool -exportcert \
   -alias "$KEY_ALIAS" \
   -keystore "$KEYSTORE_IN" \
-  -storepass "$KEYSTORE_PASS" \
+  -storepass:env KS_PASS \
   -rfc \
   -file certificate.pem
 
@@ -17,22 +21,25 @@ keytool -exportcert \
 keytool -importkeystore \
   -srckeystore "$KEYSTORE_IN" \
   -srcalias "$KEY_ALIAS" \
-  -srcstorepass "$KEYSTORE_PASS" \
+  -srcstorepass:env KS_PASS \
   -destkeystore keystore.p12 \
   -deststoretype PKCS12 \
-  -deststorepass "$KEYSTORE_PASS"
+  -deststorepass:env KS_PASS
 
 # Import into new JKS keystore
 keytool -importkeystore \
   -destkeystore "$KEYSTORE_OUT" \
   -deststoretype JKS \
-  -deststorepass "$KEYSTORE_PASS" \
+  -deststorepass:env KS_PASS \
   -srckeystore keystore.p12 \
   -srcstoretype PKCS12 \
-  -srcstorepass "$KEYSTORE_PASS" \
+  -srcstorepass:env KS_PASS \
   -alias "$KEY_ALIAS"
 
-keytool -list -v -keystore "$KEYSTORE_OUT" -storepass "$KEYSTORE_PASS"
+keytool -list -v -keystore "$KEYSTORE_OUT" -storepass:env KS_PASS
+
+# Unset sensitive environment variable
+unset KS_PASS
 
 # Clean up temporary files
 rm certificate.pem keystore.p12


### PR DESCRIPTION
As Sentinel 🛡️, I have implemented several security fixes and enhancements:

1.  **Command Injection Fix (`oc` function):** Corrected a regression where arguments were being passed unescaped to a secondary shell in `tmux`. I replaced the use of `$*` with the properly escaped `${args_escaped}` variable.
2.  **Hardened `gitnr` function:** Added double quotes to variables and utilized the `--` delimiter to prevent option injection. I also replaced `;` with `&&` to ensure the script fails early if a directory cannot be created or entered.
3.  **Secure Credential Handling:** Modified `scripts/convert-android-keystore.sh` to use environment variables for `keytool` passwords (`-storepass:env`). This prevents sensitive passwords from being exposed in the system's process list.
4.  **Journal Update:** Added a new entry to `.jules/sentinel.md` documenting the regression learning.

All changes have been verified for syntax and compliance with the repository's folder contracts.

---
*PR created automatically by Jules for task [13409273723919277854](https://jules.google.com/task/13409273723919277854) started by @dreamora*