### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix injection vulnerability in manp function

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -22,3 +22,8 @@
 **Vulnerability:** A previous fix for the `oc` function prepared an `args_escaped` variable using `printf %q` but failed to actually use it in the `tmux new-session` command, continuing to use the vulnerable `$*`.
 **Learning:** Security fixes must be verified not only for their presence but for their actual integration into the execution path. Unused security variables provide no protection.
 **Prevention:** Always verify that prepared security-hardened variables are correctly referenced in the final command construction.
+
+## 2025-05-14 - [Command and Option Injection in manp function]
+**Vulnerability:** The `manp` function in `homedir/.shellfn` used an unquoted `$1` variable in the `man` command, allowing for argument splitting and potential command injection if combined with other vulnerabilities. It also lacked the `--` delimiter, making it vulnerable to option injection.
+**Learning:** Even simple wrapper functions for standard commands like `man` must be hardened with proper quoting and delimiters to prevent malicious input from altering command behavior.
+**Prevention:** Always use double quotes `"$1"` and the `--` delimiter when passing user-provided input as a positional argument to a command.

--- a/homedir/.shellfn
+++ b/homedir/.shellfn
@@ -119,7 +119,8 @@ function gitnr() {
 
 # Use Mac OS Preview to open a man page in a more handsome format
 function manp() {
-  man -t $1 | open -f -a /Applications/Preview.app
+  # Defensive coding: quote variables and use -- to prevent option injection
+  man -t -- "$1" | open -f -a /Applications/Preview.app
 }
 
 ## hammer a service with curl for a given number of times


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Unquoted variable and missing delimiter in `manp` shell function.
🎯 Impact: Allows for argument splitting and option injection. Malicious input could cause `man` to interpret flags or split arguments, potentially leading to unexpected behavior or facilitating further attacks.
🔧 Fix: Double-quoted `"$1"` and added `--` delimiter to the `man` command in `manp`.
✅ Verification: Verified using a reproduction script that mocks `man` and demonstrates correct argument handling for input containing spaces and leading dashes.

---
*PR created automatically by Jules for task [4140409567067863450](https://jules.google.com/task/4140409567067863450) started by @dreamora*