### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix option injection in line_extract.sh

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -31,3 +31,8 @@
 **Vulnerability:** The `manp` function in `homedir/.shellfn` used an unquoted `$1` variable in the `man` command, allowing for argument splitting and potential command injection if combined with other vulnerabilities. It also lacked the `--` delimiter, making it vulnerable to option injection.
 **Learning:** Even simple wrapper functions for standard commands like `man` must be hardened with proper quoting and delimiters to prevent malicious input from altering command behavior.
 **Prevention:** Always use double quotes `"$1"` and the `--` delimiter when passing user-provided input as a positional argument to a command.
+
+## 2026-06-22 - [Option Injection in line_extract.sh]
+**Vulnerability:** User-provided patterns starting with a dash (e.g., `-v`) in `scripts/line_extract.sh` were interpreted as `grep` options because they were not preceded by `-e` and the filename was not preceded by `--`.
+**Learning:** Wrapper scripts for CLI tools must explicitly distinguish between options and positional arguments to prevent malicious or accidental option injection.
+**Prevention:** Always use `-e` for patterns and `--` for file arguments in shell scripts that wrap `grep`.

--- a/scripts/line_extract.sh
+++ b/scripts/line_extract.sh
@@ -19,4 +19,5 @@ if [[ ! -f "$FILE" ]]; then
 fi
 
 # Extract lines matching the regex pattern
-grep -E "$PATTERN" "$FILE"
+# Defensive coding: use -e and -- to prevent pattern/file from being interpreted as options
+grep -E -e "$PATTERN" -- "$FILE"


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: User-provided patterns starting with a dash (e.g., `-v`) were interpreted as `grep` options in `scripts/line_extract.sh`.
🎯 Impact: This could lead to unintended command behavior, such as inverting matches, listing files, or causing the script to hang while waiting for stdin (as it consumes the filename as the pattern).
🔧 Fix: Hardened the `grep` call by adding the `-e` flag to specify the pattern and the `--` delimiter to separate options from the file path.
✅ Verification: Successfully verified using a reproduction script that `-v` is now treated as a literal search pattern. Folder contracts were also verified to ensure no regressions in script execution. Updated the Sentinel security journal.

---
*PR created automatically by Jules for task [7520173212927255603](https://jules.google.com/task/7520173212927255603) started by @dreamora*