### PR TITLE
🛡️ Sentinel: [HIGH] Harden convert-android-keystore.sh script

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -31,3 +31,8 @@
 **Vulnerability:** The `manp` function in `homedir/.shellfn` used an unquoted `$1` variable in the `man` command, allowing for argument splitting and potential command injection if combined with other vulnerabilities. It also lacked the `--` delimiter, making it vulnerable to option injection.
 **Learning:** Even simple wrapper functions for standard commands like `man` must be hardened with proper quoting and delimiters to prevent malicious input from altering command behavior.
 **Prevention:** Always use double quotes `"$1"` and the `--` delimiter when passing user-provided input as a positional argument to a command.
+
+## 2025-05-15 - [Secure Temporary Storage and Environment Isolation for Sensitive CLI Tools]
+**Vulnerability:** `scripts/convert-android-keystore.sh` created sensitive intermediate files in the current working directory and relied on a manual `rm` at the end for cleanup. If the script failed, these files (potentially containing private keys) remained on disk. Additionally, secrets were globally exported to the environment.
+**Learning:** Manual cleanup is not fail-secure. Scoped environment variables are preferred over global exports for sensitive credentials used by sub-processes.
+**Prevention:** Use `mktemp -d` with `trap 'rm -rf "$TMP_DIR"' EXIT` for all sensitive intermediate artifacts. Scope environment variables directly to the commands that need them (e.g., `VAR=val cmd`) to minimize exposure.

--- a/scripts/convert-android-keystore.sh
+++ b/scripts/convert-android-keystore.sh
@@ -1,46 +1,55 @@
 #!/bin/bash
 
-KEY_ALIAS=$1
-KEYSTORE_PASS=$2
-KEYSTORE_IN=$3
-KEYSTORE_OUT=$4
+set -e
+
+# Security Hardening: Wrap all variables in double quotes, use secure temporary
+# directory, and implement trap for cleanup.
+
+if [[ $# -ne 4 ]]; then
+  echo "Usage: $0 <alias> <password> <keystore_in> <keystore_out>"
+  exit 1
+fi
+
+KEY_ALIAS="$1"
+KEYSTORE_PASS="$2"
+KEYSTORE_IN="$3"
+KEYSTORE_OUT="$4"
+
+# Create a secure temporary directory for intermediate files
+TMP_DIR=$(mktemp -d)
+# Ensure cleanup on exit
+trap 'rm -rf "$TMP_DIR"' EXIT
 
 # Security Standard: Passwords should be passed via environment variables
 # to prevent them from appearing in the process list.
-export KS_PASS="$KEYSTORE_PASS"
+# We set KS_PASS here but don't export it globally.
+KS_PASS="$KEYSTORE_PASS"
 
 # Export certificate
-keytool -exportcert \
+KS_PASS="$KS_PASS" keytool -exportcert \
   -alias "$KEY_ALIAS" \
   -keystore "$KEYSTORE_IN" \
   -storepass:env KS_PASS \
   -rfc \
-  -file certificate.pem
+  -file "$TMP_DIR/certificate.pem"
 
 # Export to PKCS#12
-keytool -importkeystore \
+KS_PASS="$KS_PASS" keytool -importkeystore \
   -srckeystore "$KEYSTORE_IN" \
   -srcalias "$KEY_ALIAS" \
   -srcstorepass:env KS_PASS \
-  -destkeystore keystore.p12 \
+  -destkeystore "$TMP_DIR/keystore.p12" \
   -deststoretype PKCS12 \
   -deststorepass:env KS_PASS
 
 # Import into new JKS keystore
-keytool -importkeystore \
+KS_PASS="$KS_PASS" keytool -importkeystore \
   -destkeystore "$KEYSTORE_OUT" \
   -deststoretype JKS \
   -deststorepass:env KS_PASS \
-  -srckeystore keystore.p12 \
+  -srckeystore "$TMP_DIR/keystore.p12" \
   -srcstoretype PKCS12 \
   -srcstorepass:env KS_PASS \
   -alias "$KEY_ALIAS"
 
-keytool -list -v -keystore "$KEYSTORE_OUT" -storepass:env KS_PASS
-
-# Unset sensitive environment variable
-unset KS_PASS
-
-# Clean up temporary files
-rm certificate.pem keystore.p12
-
+KS_PASS="$KS_PASS" keytool -list -v -keystore "$KEYSTORE_OUT" -storepass:env KS_PASS


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The script handled sensitive intermediate files (certificate.pem, keystore.p12) in the current working directory and lacked guaranteed cleanup on failure. It also globally exported secrets.
🎯 Impact: Sensitive keystore data or certificates could be left on disk if the script failed. Globally exported secrets could be exposed to other processes in the same environment.
🔧 Fix:
- Implemented `mktemp -d` for a secure, isolated temporary directory.
- Added `trap 'rm -rf "$TMP_DIR"' EXIT` for guaranteed cleanup of sensitive artifacts.
- Scoped the `KS_PASS` environment variable directly to `keytool` commands instead of global export.
- Added `set -e`, input validation, and proper quoting for all variables.
✅ Verification: Verified syntax with `bash -n` and performed manual code review.

---
*PR created automatically by Jules for task [9842201490728885722](https://jules.google.com/task/9842201490728885722) started by @dreamora*